### PR TITLE
Runtime bump, try 25.08

### DIFF
--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -31,7 +31,6 @@ cleanup:
   - "/include"
   - "/lib/cmake"
   - "/lib/pkgconfig"
-  - "/share/man"
   - "*.la"
   - "*.a"
 

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -58,6 +58,8 @@ modules:
 
   - name: libmodplug
     buildsystem: autotools
+    build-options:
+      cxxflags: "-O3 -Wno-register" # for fastmix logs because c17 std doesnt like usage of `register`
     cleanup:
       - /include
       - /lib/*.la

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -15,13 +15,13 @@ finish-args:
   - --filesystem=xdg-run/discord-ipc-0
 
 add-extensions:
-  com.valvesoftware.Steam.Utility.gamescope:
-    version: stable
-    add-ld-path: lib
-    no-autodownload: true
-    autodelete: true
+  org.freedesktop.Platform.VulkanLayer.gamescope:
     directory: utils/gamescope
-
+    version: '25.08'
+    add-ld-path: lib
+    no-autodownload: false
+    autodelete: true
+    
 cleanup-commands:
   - mkdir -p /app/utils/gamescope
 

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -19,7 +19,7 @@ add-extensions:
     directory: utils/gamescope
     version: '25.08'
     add-ld-path: lib
-    no-autodownload: false
+    no-autodownload: true
     autodelete: true
     
 cleanup-commands:

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -1,6 +1,6 @@
 app-id: org.srb2.SRB2Kart-galaxy
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: srb2kart.sh
 finish-args:
@@ -25,24 +25,34 @@ add-extensions:
 cleanup-commands:
   - mkdir -p /app/utils/gamescope
 
+cleanup:
+  - "/include"
+  - "/lib/cmake"
+  - "/lib/pkgconfig"
+  - "/share/man"
+  - "*.la"
+  - "*.a"
+
 modules:
   - shared-modules/glu/glu-9.json
 
-  - name: game-music-emu
+  - name: libgme
     buildsystem: cmake-ninja
-    cleanup:
-      - /include
-      - /lib/*.so
-      - /lib/pkgconfig
+    config-opts: 
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    # cleanup:
+    #   - /include
+    #   - /lib/*.so
+    #   - /lib/pkgconfig
     sources:
       - type: archive
-        url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
-        sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
+        url: https://github.com/libgme/game-music-emu/releases/download/0.6.4/libgme-0.6.4-src.tar.gz
+        sha256: 6f94eac735d86bca998a7ce1170d007995191ef6d4388345a0dc5ffa1de0bafa
         x-checker-data:
           type: anitya
           project-id: 866
           stable-only: true
-          url-template: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-$version.tar.xz
+          url-template: https://github.com/libgme/game-music-emu/releases/download/$version/libgme-$version-src.tar.gz
 
   - name: libmodplug
     buildsystem: autotools
@@ -78,6 +88,8 @@ modules:
       - -DRAPIDJSON_BUILD_EXAMPLES=OFF
       - -DRAPIDJSON_BUILD_TESTS=OFF
       - -DRAPIDJSON_BUILD_THIRDPARTY_GTEST=OFF
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DCMAKE_INSTALL_LIBDIR=lib
     cleanup:
       - /include
       - /lib/cmake
@@ -85,19 +97,20 @@ modules:
       - /share/doc
     sources:
       - type: archive
-        url: https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz
-        sha256: bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
-        x-checker-data:
-          type: anitya
-          project-id: 7422
-          stable-only: true
-          url-template: https://github.com/Tencent/rapidjson/archive/refs/tags/v$version.tar.gz
+        # latest commit as of 2026-02
+        url: https://github.com/Tencent/rapidjson/archive/24b5e7a8b27f42fa16b96fc70aade9106cf7102f.tar.gz
+        sha256: 2d2601a82d2d3b7e143a3c8d43ef616671391034bc46891a9816b79cf2d3e7a8
 
   - name: discord-rpc
+    build-options:
+      cflags: "-O3 -Wno-error"
+      cxxflags: "-O3 -Wno-error"
     buildsystem: cmake-ninja
     config-opts:
       - -DBUILD_SHARED_LIBS=ON
       - -DBUILD_EXAMPLES=OFF
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DCMAKE_INSTALL_LIBDIR=lib
     cleanup:
       - /include
     sources:
@@ -108,6 +121,12 @@ modules:
   - name: srb2kart
     buildsystem: simple
     build-options:
+      env:
+        LDFLAGS: "-L/app/lib -L/app/lib64"
+        CPPFLAGS: "-I/app/include"
+        CFLAGS: "-O3 -std=gnu17 -I/app/include"
+        CXXFLAGS: "-O3 -std=gnu++17 -I/app/include"
+        PKG_CONFIG_PATH: "/app/lib/pkgconfig:/app/share/pkgconfig"
       arch:
         aarch64:
           env:
@@ -116,7 +135,13 @@ modules:
           env:
             ARCH_MAKE_ARGS: LINUX64=1 X86_64=1
     build-commands:
-      - make -C src -j $FLATPAK_BUILDER_N_JOBS NOUPX=1 SDL=1 HAVE_DISCORDRPC=1 $ARCH_MAKE_ARGS
+      - >
+        make -C src -j $FLATPAK_BUILDER_N_JOBS 
+        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1 
+        HAVE_GME=1 GME_CFLAGS="-I/app/include" GME_LDFLAGS="-L/app/lib -lgme"
+        HAVE_LIBXMP=1 LIBXMP_CFLAGS="-I/app/include" LIBXMP_LDFLAGS="-L/app/lib -lxmp"
+        HAVE_FLUIDSYNTH=1 FLUID_CFLAGS="-I/app/include" FLUID_LDFLAGS="-L/app/lib -lfluidsynth"
+        $ARCH_MAKE_ARGS
       - install -D -m 755 bin/Linux*/Release/lsdl2srb2kart $FLATPAK_DEST/bin/srb2kart
       - install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
       - install -D -m 644 src/sdl/srb2icon.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/$FLATPAK_ID.png

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -78,7 +78,7 @@ modules:
       - /lib/pkgconfig
     sources:
       - type: archive
-        url: https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-2.6.3.tar.gz
+        url: https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-2.8.1.tar.gz
         sha256: 91dd065e9e63f499e5317350b110184b0ba96bc5f63c39b3a9939a136c40c035
 
   - name: rapidjson

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -79,7 +79,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-2.8.1.tar.gz
-        sha256: 91dd065e9e63f499e5317350b110184b0ba96bc5f63c39b3a9939a136c40c035
+        sha256: 63804b4b2ba503865c0853f102231aeff489b1dfc6dea4750a69e2a8ef54b2bb
 
   - name: rapidjson
     buildsystem: cmake-ninja

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -137,10 +137,7 @@ modules:
     build-commands:
       - >
         make -C src -j $FLATPAK_BUILDER_N_JOBS 
-        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1 
-        HAVE_GME=1 GME_CFLAGS="-I/app/include" GME_LDFLAGS="-L/app/lib -lgme"
-        HAVE_LIBXMP=1 LIBXMP_CFLAGS="-I/app/include" LIBXMP_LDFLAGS="-L/app/lib -lxmp"
-        HAVE_FLUIDSYNTH=1 FLUID_CFLAGS="-I/app/include" FLUID_LDFLAGS="-L/app/lib -lfluidsynth"
+        NOUPX=1 SDL=1 HAVE_DISCORDRPC=1
         $ARCH_MAKE_ARGS
       - install -D -m 755 bin/Linux*/Release/lsdl2srb2kart $FLATPAK_DEST/bin/srb2kart
       - install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png

--- a/org.srb2.SRB2Kart-galaxy.yaml
+++ b/org.srb2.SRB2Kart-galaxy.yaml
@@ -13,17 +13,19 @@ finish-args:
   - --persist=.srb2kart
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
+  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
+  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/gamescope/lib
 
 add-extensions:
   org.freedesktop.Platform.VulkanLayer.gamescope:
-    directory: utils/gamescope
-    version: '25.08'
+    directory: lib/extensions/vulkan/gamescope
+    version: '25.08' 
     add-ld-path: lib
     no-autodownload: true
     autodelete: true
-    
+
 cleanup-commands:
-  - mkdir -p /app/utils/gamescope
+  - mkdir -p /app/lib/extensions/vulkan/gamescope
 
 cleanup:
   - "/include"


### PR DESCRIPTION
Mostly the same as [this PR](https://github.com/flathub/org.srb2.SRB2Kart/pull/69) on `flathub/org.srb2.SRB2Kart`

this PR updates some dependencies and (most importantly) updates the freedesktop runtime from 22.08 to 25.08
tested this and verified that it works on my Ubuntu 25.04 (aarch64) VM

thanks